### PR TITLE
fix: update deprecated paths

### DIFF
--- a/src/aiodukeenergy/dukeenergy.py
+++ b/src/aiodukeenergy/dukeenergy.py
@@ -9,7 +9,6 @@ import aiohttp
 import yarl
 
 _BASE_URL = yarl.URL("https://api-v2.cma.duke-energy.app")
-_SERVICES_URL = _BASE_URL.joinpath("login-services")
 
 # Client ID and Secret are from the iOS app
 _TOKEN_URL = _BASE_URL.joinpath("login-services", "auth-token")
@@ -89,7 +88,7 @@ class DukeEnergy:
             await self._validate_auth()
 
         account_list = await self._get_json(
-            _SERVICES_URL.joinpath("account-list"),
+            _BASE_URL.joinpath("account-list"),
             {
                 "email": self.email,
                 "internalUserID": self.internal_user_id,
@@ -100,7 +99,7 @@ class DukeEnergy:
         accounts = {}
         for account in account_list["accounts"]:
             details = await self._get_json(
-                _SERVICES_URL.joinpath("account-details-v2"),
+                _BASE_URL.joinpath("account-details-v2"),
                 {
                     "email": self.email,
                     "srcSysCd": account["srcSysCd"],
@@ -169,7 +168,7 @@ class DukeEnergy:
             raise ValueError(f"Meter {serial_number} not found")
 
         result = await self._get_json(
-            _SERVICES_URL.joinpath("account", "usage", "graph"),
+            _BASE_URL.joinpath("account", "usage", "graph"),
             {
                 "srcSysCd": meter["account"]["srcSysCd"],
                 "srcAcctId": meter["account"]["srcAcctId"],

--- a/src/aiodukeenergy/dukeenergy.py
+++ b/src/aiodukeenergy/dukeenergy.py
@@ -8,13 +8,13 @@ from typing import Any, Literal
 import aiohttp
 import yarl
 
-_BASE_URL = yarl.URL("https://prod.apigee.duke-energy.app/gep/v2")
-_SERVICES_URL = _BASE_URL.joinpath("auth-services")
+_BASE_URL = yarl.URL("https://api-v2.cma.duke-energy.app")
+_SERVICES_URL = _BASE_URL.joinpath("login-services")
 
-# Client ID and Secret are from the Android app
-_TOKEN_URL = _BASE_URL.joinpath("auth-oauth2", "token")
-_CLIENT_ID = "g3c4MJTD3lciM2UoJA8CZkBIM87ckAkRXxeK5HpuzL5iVN28"
-_CLIENT_SECRET = "w4O5CxynH0M4zzRhCOaFyKplHV50GnQYyR2rxDbMBsUQ9qYlVOGRYuHg7hiXKtje"  # noqa: S105
+# Client ID and Secret are from the iOS app
+_TOKEN_URL = _BASE_URL.joinpath("login-services", "auth-token")
+_CLIENT_ID = "ShOncX64eXKHMt4IVaaLz9bPxhmCp2y27rvxK3ZLXFnPA2BF"
+_CLIENT_SECRET = "J3eHfLDJVDZL8TSNjBbcgOkBmLQPfGDXqffLEgBKj8orXkwEueK6xxEA7fDM0fQ6"  # noqa: S105
 _TOKEN_AUTH = base64.b64encode(f"{_CLIENT_ID}:{_CLIENT_SECRET}".encode()).decode()
 
 _DATE_FORMAT = "%m/%d/%Y"
@@ -169,7 +169,7 @@ class DukeEnergy:
             raise ValueError(f"Meter {serial_number} not found")
 
         result = await self._get_json(
-            _SERVICES_URL.joinpath("energy-usage-graph"),
+            _SERVICES_URL.joinpath("account", "usage", "graph"),
             {
                 "srcSysCd": meter["account"]["srcSysCd"],
                 "srcAcctId": meter["account"]["srcAcctId"],

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -69,7 +69,7 @@ async def test_simple_requests():
         assert client.password == "passwd"  # noqa: S105
         assert client._created_session is True
         mocked.post(
-            "https://prod.apigee.duke-energy.app/gep/v2/auth-oauth2/token",
+            "https://api-v2.cma.duke-energy.app/login-services/auth-token",
             payload={
                 "refresh_token_expires_in": "86399",
                 "issued_at": str(int(datetime.now(timezone.utc).timestamp() * 1000)),
@@ -97,7 +97,7 @@ async def test_simple_requests():
             },
         )
         pattern = re.compile(
-            r"^https://prod.apigee\.duke-energy\.app/gep/v2/auth-services/account-list"
+            r"^https://api-v2\.cma\.duke-energy\.app/login-services/account-list"
         )
         mocked.get(
             pattern,
@@ -118,7 +118,7 @@ async def test_simple_requests():
             },
         )
         pattern = re.compile(
-            r"^https://prod.apigee\.duke-energy\.app/gep/v2/auth-services/account-details-v2"
+            r"^https://api-v2\.cma\.duke-energy\.app/login-services/account-details-v2"
         )
         mocked.get(
             pattern,
@@ -137,7 +137,7 @@ async def test_simple_requests():
         meters = await client.get_meters()
         serial_number = next(iter(meters.keys()))
         pattern = re.compile(
-            r"^https://prod.apigee\.duke-energy\.app/gep/v2/auth-services/energy-usage-graph.*meterSerialNumber="
+            r"^https://api-v2\.cma\.duke-energy\.app/login-services/account/usage/graph.*meterSerialNumber="
         )
         mocked.get(
             pattern,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -97,7 +97,7 @@ async def test_simple_requests():
             },
         )
         pattern = re.compile(
-            r"^https://api-v2\.cma\.duke-energy\.app/login-services/account-list"
+            r"^https://api-v2\.cma\.duke-energy\.app/account-list"
         )
         mocked.get(
             pattern,
@@ -118,7 +118,7 @@ async def test_simple_requests():
             },
         )
         pattern = re.compile(
-            r"^https://api-v2\.cma\.duke-energy\.app/login-services/account-details-v2"
+            r"^https://api-v2\.cma\.duke-energy\.app/account-details-v2"
         )
         mocked.get(
             pattern,
@@ -137,7 +137,7 @@ async def test_simple_requests():
         meters = await client.get_meters()
         serial_number = next(iter(meters.keys()))
         pattern = re.compile(
-            r"^https://api-v2\.cma\.duke-energy\.app/login-services/account/usage/graph.*meterSerialNumber="
+            r"^https://api-v2\.cma\.duke-energy\.app/account/usage/graph.*meterSerialNumber="
         )
         mocked.get(
             pattern,


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/hunterjm/aiodukeenergy/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
It appears that the Duke Energy API endpoints have changed. This PR updates the deprecated endpoints.

- Use the updated URLs/endpoints mentioned in https://github.com/home-assistant/core/issues/136768#issuecomment-2625050207 to address deprecated URLs/endpoints.
- Fixes home-assistant/core/issues/136768

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/hunterjm/aiodukeenergy/blob/main/CONTRIBUTING.md).
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
