### PR TITLE
Updated authentication credentials from iOS app version 6.17.0

### DIFF
--- a/src/aiodukeenergy/dukeenergy.py
+++ b/src/aiodukeenergy/dukeenergy.py
@@ -12,8 +12,8 @@ _BASE_URL = yarl.URL("https://api-v2.cma.duke-energy.app")
 
 # Client ID and Secret are from the iOS app
 _TOKEN_URL = _BASE_URL.joinpath("login-services", "auth-token")
-_CLIENT_ID = "ShOncX64eXKHMt4IVaaLz9bPxhmCp2y27rvxK3ZLXFnPA2BF"
-_CLIENT_SECRET = "J3eHfLDJVDZL8TSNjBbcgOkBmLQPfGDXqffLEgBKj8orXkwEueK6xxEA7fDM0fQ6"  # noqa: S105
+_CLIENT_ID = "dCEIvZWA7BJcuhmjBFJlhCuHCd6bTGhkmbHP0XCrmAt6nSl0"
+_CLIENT_SECRET = "ua9DBZlebcFC334OhZIJPlNNnqWaKRnrq7ySTDGV2lVq5U9AweQb8XqVhc43vEIp"  # noqa: S105
 _TOKEN_AUTH = base64.b64encode(f"{_CLIENT_ID}:{_CLIENT_SECRET}".encode()).decode()
 
 _DATE_FORMAT = "%m/%d/%Y"


### PR DESCRIPTION
Duke updated their iOS app, and have rolled their authentication credentials as of app version 6.17.0. This update will prevent `aiohttp.client_exceptions.ClientResponseError: 403, message='Forbidden', url='https://api-v2.cma.duke-energy.app/login-services/auth-token'` (until they change the credentials again in the future)