### PR TITLE
fix: expected_series format check for DAILY values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+.DS_Store

--- a/src/aiodukeenergy/__init__.py
+++ b/src/aiodukeenergy/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 from .auth0 import Auth0Client
 from .duke_auth import AbstractDukeEnergyAuth, DukeEnergyAuth

--- a/src/aiodukeenergy/dukeenergy.py
+++ b/src/aiodukeenergy/dukeenergy.py
@@ -236,7 +236,7 @@ class DukeEnergy:
             expected_series = (
                 date.strftime("%I %p")
                 if interval == "HOURLY"
-                else date.strftime("%m/%d/%Y")
+                else date.strftime("%-m/%d/%Y")
             )
 
             # Skip duplicate dates

--- a/src/aiodukeenergy/dukeenergy.py
+++ b/src/aiodukeenergy/dukeenergy.py
@@ -186,7 +186,20 @@ class DukeEnergy:
                 "serviceType": meter["serviceType"],
                 "intervalFrequency": interval,
                 "periodType": period,
-                "date": start_date.strftime(_DATE_FORMAT),
+                # Duke Energy API expects the year, month, and day (if hourly) to match 
+                # the startDate, with the current time. Odd, but matching POST reqeusts.
+                "date": ( 
+                    datetime.now(start_date.tzinfo).replace(
+                        year=start_date.year,
+                        month=start_date.month,
+                        day=start_date.day,
+                    )
+                    if interval == "HOURLY"
+                    else datetime.now(start_date.tzinfo).replace(
+                        year=start_date.year,
+                        month=start_date.month,
+                    )
+                ).isoformat(timespec="milliseconds"),
                 "includeWeatherData": "true" if include_temperature else "false",
                 "agrmtStartDt": datetime.strptime(
                     meter["agreementActiveDate"], "%Y-%m-%d"
@@ -236,7 +249,7 @@ class DukeEnergy:
             expected_series = (
                 date.strftime("%I %p")
                 if interval == "HOURLY"
-                else date.strftime("%-m/%d/%Y")
+                else f"{date.month}/{date.strftime('%d/%Y')}"
             )
 
             # Skip duplicate dates

--- a/src/aiodukeenergy/dukeenergy.py
+++ b/src/aiodukeenergy/dukeenergy.py
@@ -186,9 +186,9 @@ class DukeEnergy:
                 "serviceType": meter["serviceType"],
                 "intervalFrequency": interval,
                 "periodType": period,
-                # Duke Energy API expects the year, month, and day (if hourly) to match 
-                # the startDate, with the current time. Odd, but matching POST reqeusts.
-                "date": ( 
+                # Duke Energy API expects year+month+day (hourly) or year+month (daily)
+                # from startDate, combined with the current time of day.
+                "date": (
                     datetime.now(start_date.tzinfo).replace(
                         year=start_date.year,
                         month=start_date.month,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -158,11 +158,11 @@ def mock_usage_data():
 def mock_daily_usage_data():
     """Create mock usage data for daily interval."""
     daily_data = []
-    start = datetime.strptime("2024-01-01", "%Y-%-m-%d")
+    start = datetime.strptime("2024-01-01", "%Y-%m-%d")
 
     for day in range(31):
         current_date = start + timedelta(days=day)
-        date_str = current_date.strftime("%-m/%d/%Y")
+        date_str = f"{current_date.month}/{current_date.strftime('%d/%Y')}"
         # Day 3 (index 2) will have 0 usage (detected as missing)
         usage_value = "0" if day == 2 else str(day * 10)
         daily_data.append(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -158,11 +158,11 @@ def mock_usage_data():
 def mock_daily_usage_data():
     """Create mock usage data for daily interval."""
     daily_data = []
-    start = datetime.strptime("2024-01-01", "%Y-%m-%d")
+    start = datetime.strptime("2024-01-01", "%Y-%-m-%d")
 
     for day in range(31):
         current_date = start + timedelta(days=day)
-        date_str = current_date.strftime("%m/%d/%Y")
+        date_str = current_date.strftime("%-m/%d/%Y")
         # Day 3 (index 2) will have 0 usage (detected as missing)
         usage_value = "0" if day == 2 else str(day * 10)
         daily_data.append(


### PR DESCRIPTION
Remove leading 0 from date check to prevent return missing for all DAILY values.

Duke returns daily values formatted as 'date': '3/09/2023'. Existing expected_series expected a '03/09/2023'  format and caused all results to be returned as 'Missing data'. 

This plus some minor tweaks to the coordinator enabled Gas readings for me. Great work on implementing OAuth and getting this project where it is!

Edit: Update example dates to be more explicit that the leading zero is kept on the day value.

<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/hunterjm/aiodukeenergy/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] This pull request follows the [contributing guidelines](https://github.com/hunterjm/aiodukeenergy/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
