### PR TITLE
Daily energy usage fixes

### DIFF
--- a/src/aiodukeenergy/dukeenergy.py
+++ b/src/aiodukeenergy/dukeenergy.py
@@ -215,8 +215,11 @@ class DukeEnergy:
         num_expected_values = (effective_end - start_date).days + 1
 
         # Extract temperature data
-        temp_len = min(num_expected_values, usage_len)
-        temp = [usage_array[i]["temperatureAvg"] for i in range(temp_len)]
+        temp = [
+            usage_array[i]["temperatureAvg"]
+            for i in range(min(num_expected_values, usage_len))
+        ]
+        temp_len = len(temp)
 
         # If interval is hourly, multiply the number of values by 24
         if interval == "HOURLY":

--- a/src/aiodukeenergy/dukeenergy.py
+++ b/src/aiodukeenergy/dukeenergy.py
@@ -186,7 +186,7 @@ class DukeEnergy:
                 "serviceType": meter["serviceType"],
                 "intervalFrequency": interval,
                 "periodType": period,
-                #Duke uses selected date with the current date's H:M:S:M
+                # Duke uses selected date with the current date's H:M:S:M
                 "date": (
                     datetime.now(start_date.tzinfo).replace(
                         year=start_date.year,

--- a/src/aiodukeenergy/dukeenergy.py
+++ b/src/aiodukeenergy/dukeenergy.py
@@ -186,20 +186,13 @@ class DukeEnergy:
                 "serviceType": meter["serviceType"],
                 "intervalFrequency": interval,
                 "periodType": period,
-                # Duke Energy API expects year+month+day (hourly) or year+month (daily)
-                # from startDate, combined with the current time of day offset by 1.
+                #Duke uses selected date with the current date's H:M:S:M
                 "date": (
                     datetime.now(start_date.tzinfo).replace(
                         year=start_date.year,
                         month=start_date.month,
                         day=start_date.day,
                     )
-                    if interval == "HOURLY"
-                    else datetime.now(start_date.tzinfo).replace(
-                        year=start_date.year,
-                        month=start_date.month,
-                    )
-                    - timedelta(days=1)
                 ).isoformat(timespec="milliseconds"),
                 "agrmtStartDt": datetime.strptime(
                     meter["agreementActiveDate"], "%Y-%m-%d"

--- a/src/aiodukeenergy/dukeenergy.py
+++ b/src/aiodukeenergy/dukeenergy.py
@@ -211,8 +211,7 @@ class DukeEnergy:
 
         usage_array = result["usageArray"]
         usage_len = len(usage_array)
-        effective_end = min(end_date, datetime.now(end_date.tzinfo) - timedelta(days=1))
-        num_expected_values = (effective_end - start_date).days + 1
+        num_expected_values = (end_date - start_date).days + 1
 
         # Extract temperature data
         temp = [

--- a/src/aiodukeenergy/dukeenergy.py
+++ b/src/aiodukeenergy/dukeenergy.py
@@ -211,11 +211,12 @@ class DukeEnergy:
 
         usage_array = result["usageArray"]
         usage_len = len(usage_array)
-        num_expected_values = (end_date - start_date).days + 1
+        effective_end = min(end_date, datetime.now(end_date.tzinfo) - timedelta(days=1))
+        num_expected_values = (effective_end - start_date).days + 1
 
         # Extract temperature data
-        temp = [usage_array[i]["temperatureAvg"] for i in range(num_expected_values)]
-        temp_len = len(temp)
+        temp_len = min(num_expected_values, usage_len)
+        temp = [usage_array[i]["temperatureAvg"] for i in range(temp_len)]
 
         # If interval is hourly, multiply the number of values by 24
         if interval == "HOURLY":
@@ -244,6 +245,11 @@ class DukeEnergy:
                 else f"{date.month}/{date.strftime('%d/%Y')}"
             )
 
+            # If fewer entries than expected date range, treat remainder as missing
+            if n >= usage_len:
+                missing.append(date)
+                continue
+
             # Skip duplicate dates
             if n > 0 and usage_array[n]["date"] == usage_array[n - 1]["date"]:
                 duplicates += 1
@@ -255,7 +261,7 @@ class DukeEnergy:
                 offset += 1
                 continue
 
-            if n >= usage_len or not float(usage_array[n]["usage"]) > 0:
+            if not float(usage_array[n]["usage"]) > 0:
                 missing.append(date)
                 continue
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -798,9 +798,9 @@ class TestUsageAPI:
                 timestamps = sorted(result["data"].keys())
                 for i in range(1, len(timestamps)):
                     time_diff = timestamps[i] - timestamps[i - 1]
-                    assert time_diff == timedelta(hours=1), (
-                        f"Expected 1 hour difference, got {time_diff}"
-                    )
+                    assert time_diff == timedelta(
+                        hours=1
+                    ), f"Expected 1 hour difference, got {time_diff}"
 
                 # The 1 AM on day 2 should have the first value, not the duplicate
                 day2_1am = start + timedelta(days=1, hours=1)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -177,6 +177,26 @@ def mock_daily_usage_data():
 
 
 @pytest.fixture
+def mock_partial_daily_usage_data():
+    """Create mock usage data for a partial week (API returns fewer days than requested)."""
+    partial_data = []
+    start = datetime.strptime("2024-01-01", "%Y-%m-%d")
+
+    for day in range(3):
+        current_date = start + timedelta(days=day)
+        date_str = f"{current_date.month}/{current_date.strftime('%d/%Y')}"
+        partial_data.append(
+            {
+                "date": date_str,
+                "usage": str((day + 1) * 10),
+                "temperatureAvg": 30,
+            }
+        )
+
+    return partial_data
+
+
+@pytest.fixture
 def mock_duplicate_hours_data():
     """Create mock usage data with duplicate hours (simulating DST fall back)."""
     hour_formats = [
@@ -666,6 +686,60 @@ class TestUsageAPI:
                 assert missing_day in result["missing"]
 
     @pytest.mark.asyncio
+    async def test_daily_energy_usage_partial_week(
+        self,
+        mock_duke_token_response,
+        mock_account_list_response,
+        mock_account_details_response,
+        mock_partial_daily_usage_data,
+    ):
+        """Test daily energy usage when API returns fewer days than requested."""
+        test_token = _create_test_jwt(exp_offset_seconds=3600)
+        test_id_token = _create_test_jwt(exp_offset_seconds=3600)
+
+        async with aiohttp.ClientSession() as session:
+            auth0_client = Auth0Client(session)
+            auth = DukeEnergyAuth(
+                session,
+                auth0_client,
+                access_token=test_token,
+                refresh_token="refresh",  # noqa: S106
+                id_token=test_id_token,
+            )
+
+            with aioresponses() as mocked:
+                setup_auth_mocks(mocked, mock_duke_token_response)
+                setup_api_mocks(
+                    mocked,
+                    mock_account_list_response,
+                    mock_account_details_response,
+                    mock_partial_daily_usage_data,
+                )
+
+                client = DukeEnergy(auth)
+
+                meters = await client.get_meters()
+                serial_number = next(iter(meters.keys()))
+
+                # Request a full week but API only returns 3 days
+                start = datetime.strptime("2024-01-01", "%Y-%m-%d")
+                end = datetime.strptime("2024-01-07", "%Y-%m-%d")
+                result = await client.get_energy_usage(
+                    serial_number,
+                    "DAILY",
+                    "WEEK",
+                    start,
+                    end,
+                )
+
+                # Only the 3 returned days should have data
+                assert len(result["data"]) == 3
+                # The remaining 4 days should be marked missing
+                assert len(result["missing"]) == 4
+                for day in range(3, 7):
+                    assert start + timedelta(days=day) in result["missing"]
+
+    @pytest.mark.asyncio
     async def test_energy_usage_duplicate_hours(
         self,
         mock_duke_token_response,
@@ -724,17 +798,17 @@ class TestUsageAPI:
                 timestamps = sorted(result["data"].keys())
                 for i in range(1, len(timestamps)):
                     time_diff = timestamps[i] - timestamps[i - 1]
-                    assert time_diff == timedelta(
-                        hours=1
-                    ), f"Expected 1 hour difference, got {time_diff}"
+                    assert time_diff == timedelta(hours=1), (
+                        f"Expected 1 hour difference, got {time_diff}"
+                    )
 
                 # The 1 AM on day 2 should have the first value, not the duplicate
                 day2_1am = start + timedelta(days=1, hours=1)
                 if day2_1am in result["data"]:
                     energy_value = result["data"][day2_1am]["energy"]
-                    assert (
-                        energy_value != 900.0
-                    ), "Should not have the duplicate hour value (900.0)"
+                    assert energy_value != 900.0, (
+                        "Should not have the duplicate hour value (900.0)"
+                    )
 
 
 class TestErrorHandling:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -178,7 +178,7 @@ def mock_daily_usage_data():
 
 @pytest.fixture
 def mock_partial_daily_usage_data():
-    """Create mock usage data for a partial week (API returns fewer days than requested)."""
+    """Create mock usage data for a partial week (fewer days than requested)."""
     partial_data = []
     start = datetime.strptime("2024-01-01", "%Y-%m-%d")
 
@@ -806,9 +806,9 @@ class TestUsageAPI:
                 day2_1am = start + timedelta(days=1, hours=1)
                 if day2_1am in result["data"]:
                     energy_value = result["data"][day2_1am]["energy"]
-                    assert energy_value != 900.0, (
-                        "Should not have the duplicate hour value (900.0)"
-                    )
+                    assert (
+                        energy_value != 900.0
+                    ), "Should not have the duplicate hour value (900.0)"
 
 
 class TestErrorHandling:


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/hunterjm/aiodukeenergy/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

* remove forked path for date when interval is not HOURLY while maintaining H:M:S:M from datetime.now
* adds usage_len guard for temperature values if fewer results are returned than expected
* move usage_len bounds check above duplicate date check / before iterating over n
* add more test coverage for partial weeks returned by DAILY interval requests

Fixes Issue #19 as well as the below errors:

```
Unexpected error fetching Duke Energy data
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 426, in _async_refresh
    self.data = await self._async_update_data()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/duke_energy/coordinator.py", line 162, in _async_update_data
    usage, interval = await self._async_get_energy_usage(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<2 lines>...
    )
    ^
  File "/config/custom_components/duke_energy/coordinator.py", line 294, in _async_get_energy_usage
    results = await self.api.get_energy_usage(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<5 lines>...
    )
    ^
  File "/usr/local/lib/python3.14/site-packages/aiodukeenergy/dukeenergy.py", line 224, in get_energy_usage
    temp = [usage_array[i]["temperatureAvg"] for i in range(num_expected_values)]
            ~~~~~~~~~~~^^^
IndexError: list index out of range
```

```
Unexpected error fetching Duke Energy data
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 426, in _async_refresh
    self.data = await self._async_update_data()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/duke_energy/coordinator.py", line 162, in _async_update_data
    usage, interval = await self._async_get_energy_usage(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<2 lines>...
    )
    ^
  File "/config/custom_components/duke_energy/coordinator.py", line 294, in _async_get_energy_usage
    results = await self.api.get_energy_usage(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<5 lines>...
    )
    ^
  File "/config/custom_components/duke_energy/aiodukeenergy/dukeenergy.py", line 255, in get_energy_usage
    if n > 0 and usage_array[n]["date"] == usage_array[n - 1]["date"]:
                 ~~~~~~~~~~~^^^
IndexError: list index out of range
```

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/hunterjm/aiodukeenergy/blob/main/CONTRIBUTING.md).
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change `N/A`
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
